### PR TITLE
makefile: Add CROSS_COMPILE variable for compatibility

### DIFF
--- a/makefile
+++ b/makefile
@@ -65,7 +65,8 @@ ifeq ($(TARGET_BUILD_VARIANT),user)
 endif
 
 # setup toolchain prefix
-TOOLCHAIN_PREFIX ?= arm-eabi-
+CROSS_COMPILE ?= arm-eabi-
+TOOLCHAIN_PREFIX := $(CROSS_COMPILE)
 CFLAGS += -fstack-protector-all
 CFLAGS += -fno-strict-overflow
 CPPFLAGS := -fno-exceptions -fno-rtti -fno-threadsafe-statics


### PR DESCRIPTION
This is a commodity, more than something really needed.
Most people do use custom scripts to cross-compile anything
which do use kernel-style variables.

Add CROSS_COMPILE variable to be able to specify a custom
toolchain the very same way we do with kernel builds.
