### PR TITLE
msm8974: Add flag to prevent an SDIO device in the second slot to be …

### DIFF
--- a/target/msm8974/init.c
+++ b/target/msm8974/init.c
@@ -256,6 +256,7 @@ static void target_mmc_sdhci_init(void)
 		dprintf(CRITICAL, "mmc1 init failed!");
 	}
 
+#ifndef MSM8974_SDIO_DEVICE
 	/* Trying Slot 2 next */
 	config.slot = 2;
 	config.max_clk_rate = MMC_CLK_200MHZ;
@@ -274,6 +275,7 @@ static void target_mmc_sdhci_init(void)
 	}
 	else if(!dev)
 		dev = tmpdev;
+#endif
 
 	/* we need at least one mmc device */
 	ASSERT(dev);


### PR DESCRIPTION
…initialized wrong by the MMC driver (this happens in hammerhead MSM8974) and SDIO Wifi Chip stucks in a bad HW State. (This is a simple workaround for the problem - someone with better SDIO understanding could probably code a runtime solution for this)

Signed-off-by: Lucas Picchi <picchi.lucas@gmail.com>